### PR TITLE
bump: Apache Superset version to `4.1.0`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.9-slim
 
-ARG SUPERSET_VERSION=4.0.2
+ARG SUPERSET_VERSION=4.1.0
 
 LABEL maintainer="NoEnv"
 LABEL version="${SUPERSET_VERSION}"


### PR DESCRIPTION
## Why

New upstream version has been released [4.1.0, apache/superset](https://github.com/apache/superset/releases/tag/4.1.0)